### PR TITLE
Restore lexer line and col to previous when char is unread

### DIFF
--- a/lexer.cpp
+++ b/lexer.cpp
@@ -14,7 +14,7 @@ private:
   FILE *m_in;
   struct Node *m_next;
   std::string m_filename;
-  int m_line, m_col;
+  int m_line, m_col, m_prev_line, m_prev_col;
   bool m_eof;
 
 public:
@@ -41,6 +41,8 @@ Lexer::Lexer(FILE *in, const std::string &filename)
   , m_filename(filename)
   , m_line(1)
   , m_col(1)
+  , m_prev_line(1)
+  , m_prev_col(1)
   , m_eof(false) {
 }
 
@@ -78,9 +80,12 @@ int Lexer::read() {
   if (c < 0) {
     m_eof = true;
   } else if (c == '\n') {
+    m_prev_col = m_col;
+    m_prev_line = m_line;
     m_col = 1;
     m_line++;
   } else {
+    m_prev_col = m_col;
     m_col++;
   }
   return c;
@@ -90,7 +95,8 @@ int Lexer::read() {
 // that the current token has ended and the next one has begun.
 void Lexer::unread(int c) {
   ungetc(c, m_in);
-  m_col--;
+  m_col = m_prev_col;
+  m_line = m_prev_line;
 }
 
 void Lexer::fill() {


### PR DESCRIPTION
`Lexer::unread` will only decrement the current column of the lexer. However, if the lexer has to unread a newline character, then the line should be decremented and the column should be set to the length of the previous line.

With the old implementation, given this input:

```
+ 1 2
```

which is modeled after [this](https://github.com/jhucompilers/fall2021-tests/blob/master/assign01/input/error07.in) test for the infix calculator, the prefix calculator would report:

```
test.txt:3:1: Error: Unexpected end of input
```

when it should be:

```
test.txt:2:1: Error: Unexpected end of input
```

This is because when parsing for the 2, the newline gets read and the line value is incremented in `read_continued_token`. However, it then gets unread, but only the column is decremented, putting the lexer at line 2, column 0. Then, when trying to parse for the semicolon, it'll read the newline again, and put the lexer at line 3, column 1. Then the EOF is read and the error is thrown.

I've decided to keep track of the previous column and line position, and restore them if any token is unread. Perhaps a better implementation would use a stack, pushing on (line, column) pairs as they are read and popping them off and restoring them if they're unread, but `Lexer::unread` is only ever called once in a row, so keeping track of values past just the previous isn't necessary.